### PR TITLE
Multiple format support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,118 @@
+{
+    // IntelliSense を使用して利用可能な属性を学べます。
+    // 既存の属性の説明をホバーして表示します。
+    // 詳細情報は次を確認してください: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [{
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "args": [
+                "bin"
+            ]
+        },
+        {
+            "name": "Python: Attach",
+            "type": "python",
+            "request": "attach",
+            "localRoot": "${workspaceFolder}",
+            "remoteRoot": "${workspaceFolder}",
+            "port": 3000,
+            "secret": "my_secret",
+            "host": "localhost"
+        },
+        {
+            "name": "Python: Terminal (integrated)",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "Python: Terminal (external)",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "externalTerminal"
+        },
+        {
+            "name": "Python: Django",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/manage.py",
+            "args": [
+                "runserver",
+                "--noreload",
+                "--nothreading"
+            ],
+            "debugOptions": [
+                "RedirectOutput",
+                "Django"
+            ]
+        },
+        {
+            "name": "Python: Flask (0.11.x or later)",
+            "type": "python",
+            "request": "launch",
+            "module": "flask",
+            "env": {
+                "FLASK_APP": "app.py"
+            },
+            "args": [
+                "run",
+                "--no-debugger",
+                "--no-reload"
+            ]
+        },
+        {
+            "name": "Python: Module",
+            "type": "python",
+            "request": "launch",
+            "module": "module.name"
+        },
+        {
+            "name": "Python: Pyramid",
+            "type": "python",
+            "request": "launch",
+            "args": [
+                "${workspaceFolder}/development.ini"
+            ],
+            "debugOptions": [
+                "RedirectOutput",
+                "Pyramid"
+            ]
+        },
+        {
+            "name": "Python: Watson",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/console.py",
+            "args": [
+                "dev",
+                "runserver",
+                "--noreload=True"
+            ]
+        },
+        {
+            "name": "Python: All debug Options",
+            "type": "python",
+            "request": "launch",
+            "pythonPath": "${config:python.pythonPath}",
+            "program": "${file}",
+            "module": "module.name",
+            "env": {
+                "VAR1": "1",
+                "VAR2": "2"
+            },
+            "envFile": "${workspaceFolder}/.env",
+            "args": [
+                "arg1",
+                "arg2"
+            ],
+            "debugOptions": [
+                "RedirectOutput"
+            ]
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "request": "launch",
             "program": "${file}",
             "args": [
-                "bin"
+                "dec"
             ]
         },
         {

--- a/README.md
+++ b/README.md
@@ -1,14 +1,32 @@
 # MySerial
-Serial Debugger (Python pyserial Based)
+Serial Debugger based on by pyserial.
 
-# What is this python script
-this is the program for studing python 
-edit with pyserial example
+## What is this python script?
+This program is a part of my study of python.
+It is developed through editing ` pyserial` example.
 
-useing with python lancher is good for use.
 
-# How I can use it
-## firstable,ask which port do you use
-enter the number of Serial Port 
+Using with python lancher is recommended.
 
-## Next,enter baudrate value
+## Usage
+Usage is quite simple. Probably you wouldn't need this instruction but just in case.
+
+### Step0. Call this script
+
+~~~bash
+$ python Myserial.py
+~~~
+
+### Step1. Specify serial port which you'd like to connect.
+
+The prompt shows several options. Find your device and specify one of them by entering index number or its name. 
+
+### Step2. Set Baudrate
+After Step1,the prompt asks the baudrate which you'd like to use.
+Enter the baudrate numbers. 
+e,g `9600` `19200` `38400` `57600` `74880` `115200` `230400` ...
+
+**Enjoy Monitoring :)**
+
+## LICENCE 
+ MIT. See [LICENCE](./LICENCE)

--- a/myserial.py
+++ b/myserial.py
@@ -11,6 +11,7 @@ from enum import Enum
 import serial
 from serial.tools.list_ports import comports
 from serial.tools import hexlify_codec
+fmt=0
 
 
 def ask_for_port():
@@ -47,7 +48,7 @@ def printData():
     Ser.close()
 
 
-fmt=0
+
 def parseArgs():
     global fmt
     args=sys.argv
@@ -62,7 +63,6 @@ def parseArgs():
             fmt=4
         else :
             fmt=0
-
 
 
 if __name__ == "__main__":

--- a/myserial.py
+++ b/myserial.py
@@ -6,12 +6,11 @@ import os
 import sys
 import threading
 import sys
+from enum import Enum
 
 import serial
 from serial.tools.list_ports import comports
 from serial.tools import hexlify_codec
-
-
 
 
 def ask_for_port():
@@ -48,9 +47,27 @@ def printData():
     Ser.close()
 
 
+fmt=0
+def parseArgs():
+    global fmt
+    args=sys.argv
+    if len(args)>1:
+        if args[1]=='bin':
+            fmt=1
+        elif args[1]=='oct':
+            fmt=2
+        elif args[1]=='dec':
+            fmt=3
+        elif args[1]=='hex':
+            fmt=4
+        else :
+            fmt=0
+
 
 
 if __name__ == "__main__":
+    parseArgs()
     serialPort = ask_for_port()
     serialBaud = ask_baud()
+    print(fmt)
     printData()

--- a/myserial.py
+++ b/myserial.py
@@ -38,15 +38,57 @@ def ask_baud():
     baud = raw_input('--- Enter baudrate: ')
     return baud
 
-
-def printData():
-    Ser = serial.Serial(serialPort, serialBaud, timeout = None)
+def printAscii(Ser):
     while(True):
         string_data = Ser.read()
         sys.stdout.write(str(string_data))
-        # print(str(string_data),end="")
-    Ser.close()
 
+def printBin(Ser):
+    while(True):
+        data = ord(Ser.read())
+        sys.stdout.write(bin(data))
+        sys.stdout.write("\n")
+
+def printOct(Ser):
+    while(True):
+        for i in range(8):
+            data = ord(Ser.read())
+            sys.stdout.write(oct(data))
+            sys.stdout.write(" ")
+        sys.stdout.write("\n")
+
+
+def printDec(Ser):
+    while(True):
+        data = ord(Ser.read())
+        sys.stdout.write(str(data))
+        sys.stdout.write("\n")
+
+
+def printHex(Ser):
+    while(True):
+        for i in range(8):
+            string_data = ord(Ser.read())
+            sys.stdout.write(hex(string_data))
+            sys.stdout.write(" ")
+        sys.stdout.write("\n")
+
+
+
+def printData():
+    Ser = serial.Serial(serialPort, serialBaud, timeout = None)
+    
+    if fmt==1: # bin
+        printBin(Ser)
+    elif fmt==2: # oct
+        printOct(Ser)
+    elif fmt==3: # dec
+        printDec(Ser)
+    elif fmt==4: # hex
+        printHex(Ser)
+    else: # ascii
+        printAscii(Ser)
+    Ser.close()
 
 
 def parseArgs():
@@ -69,5 +111,4 @@ if __name__ == "__main__":
     parseArgs()
     serialPort = ask_for_port()
     serialBaud = ask_baud()
-    print(fmt)
     printData()


### PR DESCRIPTION
This PR includes commits which let  *MySerial* support multiple formats in addition to ascii.

# Supported Formats
- ASCII characters
- Binary numbers
- Octal numbers
- Decimal numbers
- Hexadecimal numbers


# Diff of usage
Original usages are still supported.
This PR just increases a feature.

## How to Specify Format
Just add **format syntax** like follows:
~~~bash
$ python myserial.py dec 
~~~

## Supported format syntax
|syntax|format|
|---|---|
|`bin`|Binary|
|`oct`|Octal|
|`dec`|Decimal|
|`hex`|Hexadecimal|
|`ascii` or **Ommitted** | ASCII|


# Note
This modify increase only some millseconds before `printData()`. It means this modify doesn't increase time of loop. Performance  will not be any problem.
